### PR TITLE
fix(layers): rename the layer with double click

### DIFF
--- a/src/js/events.js
+++ b/src/js/events.js
@@ -737,7 +737,7 @@ $(document).ready(function () {
 
   // Change layer name
   $(document).on('dblclick', '.layer-custom-name', function () {
-    $(this).prop('disabled', false);
+    $(this).prop('readonly', false);
     $(this).addClass('name-active');
     $(this).focus();
     document.execCommand('selectAll', false, null);

--- a/src/js/functions.js
+++ b/src/js/functions.js
@@ -3030,7 +3030,7 @@ function renderLayer(object, animate = false) {
         src +
         "><input class='layer-custom-name' value='" +
         objects.find((x) => x.id == object.get('id')).label +
-        "' disabled></span><div class='layer-options'><img class='" +
+        "' readonly></span><div class='layer-options'><img class='" +
         freeze +
         "' src='assets/" +
         freeze +
@@ -3044,7 +3044,7 @@ function renderLayer(object, animate = false) {
         src +
         "><input class='layer-custom-name' value='" +
         objects.find((x) => x.id == object.get('id')).label +
-        "' disabled></span><div class='layer-options'><img class='lock " +
+        "' readonly></span><div class='layer-options'><img class='lock " +
         classlock +
         "' src='assets/" +
         srclock +

--- a/src/js/ui.js
+++ b/src/js/ui.js
@@ -1647,7 +1647,7 @@ $(document).on('mousedown', '.delete-media', deleteMedia);
 
 // Save layer name
 function saveLayerName() {
-  $('.name-active').prop('disabled', true);
+  $('.name-active').prop('readonly', true);
   if ($('.name-active').val() == '') {
     $('.name-active').val('Untitled layer');
   }


### PR DESCRIPTION
Rename a layer was not working due to the `disabled` props. Disabled fields do not fire click handlers. 
On `inputs` fields, you can use the `readonly` props instead of `disabled`.

With the readonly, it works.

### Breaking changes

None